### PR TITLE
Add capability check for admin submission

### DIFF
--- a/elegant-popups.php
+++ b/elegant-popups.php
@@ -240,6 +240,10 @@ class ElegantPopups {
      * Page d'administration
      */
     public function admin_page() {
+        if (!current_user_can('manage_options')) {
+            wp_die(__('Vous n\'avez pas les droits nécessaires pour accéder à cette page.', ELEGANT_POPUPS_TEXT_DOMAIN));
+        }
+
         $options = get_option('elegant_popups_options', $this->default_options);
         
         if (isset($_POST['submit'])) {


### PR DESCRIPTION
## Summary
- ensure `admin_page()` only runs when user can `manage_options`

## Testing
- `npm test` *(fails: package.json missing)*
- `php -l elegant-popups.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e66e3ab0832b8841f719a8ff8439