### PR TITLE
Introduce delay before exit-intent listener

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -76,57 +76,62 @@ class ElegantPopups {
         }
         
         if (DEBUG) console.log('Setting up exit popup listeners...');
-        
-        // Détection desktop : souris qui sort du viewport
-        document.addEventListener('mouseleave', (e) => {
-            if (e.clientY <= 0 && !this.isExitIntentTriggered && !this.activePopup) {
-                if (DEBUG) console.log('Exit intent detected (mouse)');
-                this.showPopup('exit');
-                this.isExitIntentTriggered = true;
-            }
-        });
-        
-        // Détection mobile : scroll rapide vers le haut
-        let lastScrollTop = 0;
-        let scrollStartTime = 0;
-        
-        window.addEventListener('scroll', () => {
-            const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-            const currentTime = Date.now();
-            
-            if (scrollTop === 0 && lastScrollTop > 50) {
-                // Scroll rapide vers le haut sur mobile
-                if (currentTime - scrollStartTime < 500 && !this.isExitIntentTriggered && !this.activePopup) {
-                    if (DEBUG) console.log('Exit intent detected (scroll)');
+
+        // Introduce a short delay before activating the listeners to avoid false positives
+        setTimeout(() => {
+            if (DEBUG) console.log('Exit popup listeners activated');
+
+            // Détection desktop : souris qui sort du viewport
+            document.addEventListener('mouseleave', (e) => {
+                if (e.clientY <= 0 && e.relatedTarget === null && !this.isExitIntentTriggered && !this.activePopup) {
+                    if (DEBUG) console.log('Exit intent detected (mouse)');
                     this.showPopup('exit');
                     this.isExitIntentTriggered = true;
                 }
-            }
-            
-            if (scrollTop > lastScrollTop) {
-                scrollStartTime = currentTime;
-            }
-            
-            lastScrollTop = scrollTop;
-        }, { passive: true });
-        
-        // Détection mobile : geste de retour/fermeture
-        let touchStartY = 0;
-        document.addEventListener('touchstart', (e) => {
-            touchStartY = e.touches[0].clientY;
-        }, { passive: true });
-        
-        document.addEventListener('touchmove', (e) => {
-            const touchY = e.touches[0].clientY;
-            const diff = touchStartY - touchY;
-            
-            // Swipe vers le haut rapide depuis le haut de l'écran
-            if (touchStartY < 50 && diff > 100 && !this.isExitIntentTriggered && !this.activePopup) {
-                if (DEBUG) console.log('Exit intent detected (touch)');
-                this.showPopup('exit');
-                this.isExitIntentTriggered = true;
-            }
-        }, { passive: true });
+            });
+
+            // Détection mobile : scroll rapide vers le haut
+            let lastScrollTop = 0;
+            let scrollStartTime = 0;
+
+            window.addEventListener('scroll', () => {
+                const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+                const currentTime = Date.now();
+
+                if (scrollTop === 0 && lastScrollTop > 50) {
+                    // Scroll rapide vers le haut sur mobile
+                    if (currentTime - scrollStartTime < 500 && !this.isExitIntentTriggered && !this.activePopup) {
+                        if (DEBUG) console.log('Exit intent detected (scroll)');
+                        this.showPopup('exit');
+                        this.isExitIntentTriggered = true;
+                    }
+                }
+
+                if (scrollTop > lastScrollTop) {
+                    scrollStartTime = currentTime;
+                }
+
+                lastScrollTop = scrollTop;
+            }, { passive: true });
+
+            // Détection mobile : geste de retour/fermeture
+            let touchStartY = 0;
+            document.addEventListener('touchstart', (e) => {
+                touchStartY = e.touches[0].clientY;
+            }, { passive: true });
+
+            document.addEventListener('touchmove', (e) => {
+                const touchY = e.touches[0].clientY;
+                const diff = touchStartY - touchY;
+
+                // Swipe vers le haut rapide depuis le haut de l'écran
+                if (touchStartY < 50 && diff > 100 && !this.isExitIntentTriggered && !this.activePopup) {
+                    if (DEBUG) console.log('Exit intent detected (touch)');
+                    this.showPopup('exit');
+                    this.isExitIntentTriggered = true;
+                }
+            }, { passive: true });
+        }, 1000);
     }
     
     setupEventListeners() {


### PR DESCRIPTION
## Summary
- prevent false positives when mouse briefly leaves the document by checking `e.relatedTarget`
- wait 1 second after page load before registering exit-intent listeners

## Testing
- `npm test` *(fails: could not find package.json / network)*

------
https://chatgpt.com/codex/tasks/task_e_6860edf95810832ba698854a460c9d3c