### PR TITLE
Add screen reader headings

### DIFF
--- a/templates/frontend-popups.php
+++ b/templates/frontend-popups.php
@@ -11,10 +11,10 @@ if (!defined('ABSPATH')) {
     
     <!-- Pop-up d'accueil -->
     <?php if ($options['welcome_popup']['enabled']): ?>
-    <div id="elegant-welcome-popup" 
-         class="elegant-popup welcome-popup" 
-         role="dialog" 
-         aria-labelledby="welcome-popup-title" 
+    <div id="elegant-welcome-popup"
+         class="elegant-popup welcome-popup"
+         role="dialog"
+         aria-labelledby="welcome-popup-title"
          aria-hidden="true"
          data-delay="<?php echo esc_attr($options['welcome_popup']['delay']); ?>"
          data-show-once="<?php echo $options['welcome_popup']['show_once'] ? 'true' : 'false'; ?>"
@@ -27,6 +27,12 @@ if (!defined('ABSPATH')) {
             color: <?php echo esc_attr($options['welcome_popup']['text_color']); ?>;
             font-size: <?php echo esc_attr($options['welcome_popup']['font_size']); ?>px;
          ">
+
+        <h2 id="welcome-popup-title" class="elegant-popup-title">
+            <?php _e("Pop-up d'accueil", ELEGANT_POPUPS_TEXT_DOMAIN); ?>
+        </h2>
+
+
         <button class="elegant-popup-close" aria-label="<?php _e('Fermer', ELEGANT_POPUPS_TEXT_DOMAIN); ?>" tabindex="1">
             <span aria-hidden="true">&times;</span>
         </button>
@@ -39,10 +45,10 @@ if (!defined('ABSPATH')) {
     
     <!-- Pop-up de sortie -->
     <?php if ($options['exit_popup']['enabled']): ?>
-    <div id="elegant-exit-popup" 
-         class="elegant-popup exit-popup" 
-         role="dialog" 
-         aria-labelledby="exit-popup-title" 
+    <div id="elegant-exit-popup"
+         class="elegant-popup exit-popup"
+         role="dialog"
+         aria-labelledby="exit-popup-title"
          aria-hidden="true"
          style="
             width: <?php echo esc_attr($options['exit_popup']['width']); ?>px;
@@ -53,6 +59,10 @@ if (!defined('ABSPATH')) {
             color: <?php echo esc_attr($options['exit_popup']['text_color']); ?>;
             font-size: <?php echo esc_attr($options['exit_popup']['font_size']); ?>px;
          ">
+        <h2 id="exit-popup-title" class="elegant-popup-title">
+            <?php _e('Pop-up de sortie', ELEGANT_POPUPS_TEXT_DOMAIN); ?>
+        </h2>
+
         <button class="elegant-popup-close" aria-label="<?php _e('Fermer', ELEGANT_POPUPS_TEXT_DOMAIN); ?>" tabindex="1">
             <span aria-hidden="true">&times;</span>
         </button>


### PR DESCRIPTION
## Summary
- add headings for welcome and exit popups so `aria-labelledby` references exist

## Testing
- `php -l templates/frontend-popups.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860edfe1fd8832ba98fb89a2aab22a5