### PR TITLE
Improve localStorage handling

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -11,9 +11,17 @@ class ElegantPopups {
         this.isExitIntentTriggered = false;
         this.isWelcomeShown = false;
         this.activePopup = null;
-        
+        this.storageAvailable = true;
+        this.welcomeShownFallback = false;
+
         // Vérification du stockage local pour le pop-up d'accueil
-        this.welcomeShownBefore = localStorage.getItem('elegant_welcome_shown') === 'true';
+        try {
+            this.welcomeShownBefore = localStorage.getItem('elegant_welcome_shown') === 'true';
+            this.welcomeShownFallback = this.welcomeShownBefore;
+        } catch (e) {
+            this.storageAvailable = false;
+            this.welcomeShownBefore = this.welcomeShownFallback;
+        }
         
         // Debug
         if (DEBUG) console.log('ElegantPopups initialized', this.options);
@@ -205,7 +213,13 @@ class ElegantPopups {
         if (type === 'welcome') {
             this.isWelcomeShown = true;
             if (this.options.welcome_popup.show_once) {
-                localStorage.setItem('elegant_welcome_shown', 'true');
+                try {
+                    localStorage.setItem('elegant_welcome_shown', 'true');
+                    this.welcomeShownFallback = true;
+                } catch (e) {
+                    this.storageAvailable = false;
+                    this.welcomeShownFallback = true;
+                }
             }
         }
         
@@ -285,7 +299,12 @@ class ElegantPopups {
     }
     
     resetWelcomePopup() {
-        localStorage.removeItem('elegant_welcome_shown');
+        try {
+            localStorage.removeItem('elegant_welcome_shown');
+        } catch (e) {
+            this.storageAvailable = false;
+        }
+        this.welcomeShownFallback = false;
         this.welcomeShownBefore = false;
         this.isWelcomeShown = false;
     }


### PR DESCRIPTION
## Summary
- wrap localStorage access in frontend JS
- provide in-memory fallback flags for browsers where storage is unavailable

## Testing
- `npm test` *(fails: package.json not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ee00105c832b9217498b797f3391