### PR TITLE
Remove popup headers

### DIFF
--- a/templates/frontend-popups.php
+++ b/templates/frontend-popups.php
@@ -14,7 +14,7 @@ if (!defined('ABSPATH')) {
     <div id="elegant-welcome-popup"
          class="elegant-popup welcome-popup"
          role="dialog"
-         aria-labelledby="welcome-popup-title"
+         aria-label="<?php _e('Pop-up d\'accueil', ELEGANT_POPUPS_TEXT_DOMAIN); ?>"
          aria-hidden="true"
          data-delay="<?php echo esc_attr($options['welcome_popup']['delay']); ?>"
          data-show-once="<?php echo $options['welcome_popup']['show_once'] ? 'true' : 'false'; ?>"
@@ -28,9 +28,6 @@ if (!defined('ABSPATH')) {
             font-size: <?php echo esc_attr($options['welcome_popup']['font_size']); ?>px;
          ">
 
-        <h2 id="welcome-popup-title" class="elegant-popup-title">
-            <?php _e("Pop-up d'accueil", ELEGANT_POPUPS_TEXT_DOMAIN); ?>
-        </h2>
 
 
         <button class="elegant-popup-close" aria-label="<?php _e('Fermer', ELEGANT_POPUPS_TEXT_DOMAIN); ?>" tabindex="1">
@@ -48,7 +45,7 @@ if (!defined('ABSPATH')) {
     <div id="elegant-exit-popup"
          class="elegant-popup exit-popup"
          role="dialog"
-         aria-labelledby="exit-popup-title"
+         aria-label="<?php _e('Pop-up de sortie', ELEGANT_POPUPS_TEXT_DOMAIN); ?>"
          aria-hidden="true"
          style="
             width: <?php echo esc_attr($options['exit_popup']['width']); ?>px;
@@ -59,9 +56,6 @@ if (!defined('ABSPATH')) {
             color: <?php echo esc_attr($options['exit_popup']['text_color']); ?>;
             font-size: <?php echo esc_attr($options['exit_popup']['font_size']); ?>px;
          ">
-        <h2 id="exit-popup-title" class="elegant-popup-title">
-            <?php _e('Pop-up de sortie', ELEGANT_POPUPS_TEXT_DOMAIN); ?>
-        </h2>
 
         <button class="elegant-popup-close" aria-label="<?php _e('Fermer', ELEGANT_POPUPS_TEXT_DOMAIN); ?>" tabindex="1">
             <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
## Summary
- strip welcome and exit popup headers from frontend output

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68610f92cad8832b827cdd52af6ba969